### PR TITLE
Add entry point and argparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project is a study project for me to get to know python better.
 
+It has been tested with python 3.7.1
+
 ## Goal
 
 The package shall convert as much fileformats to pdf as it's possible in the
@@ -25,10 +27,26 @@ source venv/bin/activate
 python setup.py install
 ```
 
+This package needs cairo installed.
+
+## Supported Filetypes
+
+Currently supported filetypes are:
+
+    - Markdown (.md)
+    - Word Documents (.docx)
+    - RestructuredText (.rst)
+
 ## Usage
 
-The program can be started with:
+The GUI can be started with:
 
 ```zsh
 start-app
+```
+
+The CLI can be started with"
+
+```zsh
+convert output-dir input-filepath [input-filepath ...]
 ```

--- a/pdf_converter/command_line.py
+++ b/pdf_converter/command_line.py
@@ -1,6 +1,17 @@
 import argparse
 
 
+def create_output_paths(output_dir, file_paths):
+    output_file_paths = []
+    output_dir = output_dir.rstrip('/') + '/'
+    for file_path in file_paths:
+        filename_incl_ext = file_path.split('/')[-1]
+        filename = filename_incl_ext.split('.')[0]
+        output_file_paths.append(output_dir + filename + '.pdf')
+
+    return output_file_paths
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("output_dir",
@@ -14,5 +25,5 @@ def main():
                         nargs='+',
                         help="Path of file to convert")
     args = parser.parse_args()
-    print(args.output_dir)
-    print(args.file_paths)
+
+    output_paths = create_output_paths(args.output_dir[0], args.file_paths)

--- a/pdf_converter/command_line.py
+++ b/pdf_converter/command_line.py
@@ -15,35 +15,34 @@ def create_output_paths(output_dir, file_paths):
 
 
 def convert_files_to_pdf(input_file_dirs, output_file_dirs):
-
     for index, input_file_dir in enumerate(input_file_dirs):
         file_instance = converting_pdf.PdfConverter(input_file_dir)
         file_instance.set_file_format()
 
-        if not file_instance.file_format:
-            pass
-            # This could later on raise an
-            # error saying file type isn't supported.
-        else:
-            # check if already exists
-            file_exists = True
-            temp_file = Path(output_file_dirs[index] + '.pdf')
-            new_file_path = output_file_dirs[index]
-            while file_exists is True:
-                if not temp_file.is_file():
-                    file_exists = False
-                else:
-                    temp_file = Path(new_file_path + '_new' + '.pdf')
-                    new_file_path = new_file_path + '_new'
-                    file_exists = True
-            new_file_path = new_file_path + '.pdf'
+        new_file_path = create_filename(file_instance, output_file_dirs, index)
 
-            if file_instance.file_format == 'Markdown':
-                file_instance.convert_markdown(new_file_path)
-            if file_instance.file_format == 'Docx':
-                file_instance.convert_docx(new_file_path)
-            if file_instance.file_format == 'RestructuredText':
-                file_instance.convert_rst(new_file_path)
+        if file_instance.file_format == 'Markdown':
+            file_instance.convert_markdown(new_file_path)
+        if file_instance.file_format == 'Docx':
+            file_instance.convert_docx(new_file_path)
+        if file_instance.file_format == 'RestructuredText':
+            file_instance.convert_rst(new_file_path)
+
+
+def create_filename(file_instance, output_file_dirs, index):
+    if file_instance.file_format:
+        # check if already exists
+        file_exists = True
+        temp_file = Path(output_file_dirs[index] + '.pdf')
+        new_file_path = output_file_dirs[index]
+        while file_exists:
+            if not temp_file.is_file():
+                file_exists = False
+            else:
+                temp_file = Path(new_file_path + '_new' + '.pdf')
+                new_file_path = new_file_path + '_new'
+                file_exists = True
+        return new_file_path + '.pdf'
 
 
 def main():

--- a/pdf_converter/command_line.py
+++ b/pdf_converter/command_line.py
@@ -1,4 +1,5 @@
 import argparse
+from pdf_converter import converting_pdf
 
 
 def create_output_paths(output_dir, file_paths):
@@ -10,6 +11,25 @@ def create_output_paths(output_dir, file_paths):
         output_file_paths.append(output_dir + filename + '.pdf')
 
     return output_file_paths
+
+
+def convert_files_to_pdf(input_file_dirs, output_file_dirs):
+
+    for index, input_file_dir in enumerate(input_file_dirs):
+        file_instance = converting_pdf.PdfConverter(input_file_dir)
+        file_instance.set_file_format()
+
+        if not file_instance.file_format:
+            pass
+            # This could later on raise an
+            # error saying file type isn't supported.
+        else:
+            if file_instance.file_format == 'Markdown':
+                file_instance.convert_markdown(output_file_dirs[index])
+            if file_instance.file_format == 'Docx':
+                file_instance.convert_docx(output_file_dirs[index])
+            if file_instance.file_format == 'RestructuredText':
+                file_instance.convert_rst(output_file_dirs[index])
 
 
 def main():
@@ -27,3 +47,4 @@ def main():
     args = parser.parse_args()
 
     output_paths = create_output_paths(args.output_dir[0], args.file_paths)
+    convert_files_to_pdf(args.file_paths, output_paths)

--- a/pdf_converter/command_line.py
+++ b/pdf_converter/command_line.py
@@ -1,5 +1,6 @@
 import argparse
 from pdf_converter import converting_pdf
+from pathlib import Path
 
 
 def create_output_paths(output_dir, file_paths):
@@ -8,7 +9,7 @@ def create_output_paths(output_dir, file_paths):
     for file_path in file_paths:
         filename_incl_ext = file_path.split('/')[-1]
         filename = filename_incl_ext.split('.')[0]
-        output_file_paths.append(output_dir + filename + '.pdf')
+        output_file_paths.append(output_dir + filename)
 
     return output_file_paths
 
@@ -24,12 +25,25 @@ def convert_files_to_pdf(input_file_dirs, output_file_dirs):
             # This could later on raise an
             # error saying file type isn't supported.
         else:
+            # check if already exists
+            file_exists = True
+            temp_file = Path(output_file_dirs[index] + '.pdf')
+            new_file_path = output_file_dirs[index]
+            while file_exists is True:
+                if not temp_file.is_file():
+                    file_exists = False
+                else:
+                    temp_file = Path(new_file_path + '_new' + '.pdf')
+                    new_file_path = new_file_path + '_new'
+                    file_exists = True
+            new_file_path = new_file_path + '.pdf'
+
             if file_instance.file_format == 'Markdown':
-                file_instance.convert_markdown(output_file_dirs[index])
+                file_instance.convert_markdown(new_file_path)
             if file_instance.file_format == 'Docx':
-                file_instance.convert_docx(output_file_dirs[index])
+                file_instance.convert_docx(new_file_path)
             if file_instance.file_format == 'RestructuredText':
-                file_instance.convert_rst(output_file_dirs[index])
+                file_instance.convert_rst(new_file_path)
 
 
 def main():

--- a/pdf_converter/command_line.py
+++ b/pdf_converter/command_line.py
@@ -1,6 +1,18 @@
+import argparse
+
+
 def main():
-    print("This is gonna be a file to PDF converter.")
-
-
-if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir",
+                        metavar='output-directory',
+                        type=str,
+                        nargs=1,
+                        help="Path to save the file/s in")
+    parser.add_argument("file_paths",
+                        metavar='input-file',
+                        type=str,
+                        nargs='+',
+                        help="Path of file to convert")
+    args = parser.parse_args()
+    print(args.output_dir)
+    print(args.file_paths)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'start-app=pdf_converter.gui_application:main',
+            'convert=pdf_converter.command_line:main',
         ],
     },
 )


### PR DESCRIPTION
The cli enables one to convert files to pdf within the shell.

With a command like `convert output-dir filepath-to-convert [filepath-to-convert ...]` one can add a list of mixed filetypes (if supported) and they will be converted and stored in output-dir.
Also if duplicate filename exist it will concatenate `_new` to it, so they don't conflict.